### PR TITLE
Added change to the terminator so that we ignore an auto scaling grou…

### DIFF
--- a/integration/autoscalinggroup.go
+++ b/integration/autoscalinggroup.go
@@ -48,11 +48,11 @@ func (group AutoScalingGroup) GetTargetInstances(canonical semver.Version, minim
     return []string{}, nil
   }
 
-	if len(healthy) != len(group.InstanceDetails) {
+	if len(unhealthy) > 0 || len(healthy) != len(group.InstanceDetails) {
 		fmt.Printf("%s => couldn't get all instance details, some instances may still be starting\n", group.Name)
 		return []string{}, nil
 	}
-	
+
 	fmt.Printf("%s => finding instances that don't match version %s\n", group.Name, canonical)
 	var mismatchedInstances []string
 

--- a/terminator.go
+++ b/terminator.go
@@ -15,6 +15,12 @@ func terminate(cloud integration.CloudProvider, p parameters) []string {
 		fmt.Println("Terminator activated. Searching for Sarah Connor...")
 	}
 
+	canonicalVersion, err := semver.Make(p.canonical)
+	if err != nil {
+		fmt.Errorf("Failed to parse canonical version, %+v\n", err)
+		return []string{}
+	}
+
 	terminatedInstances := []string{}
 
 	groups, err := cloud.DescribeAutoScalingGroups(
@@ -25,16 +31,10 @@ func terminate(cloud integration.CloudProvider, p parameters) []string {
 
 	if err != nil {
 		fmt.Printf("Failed to get auto scaling groups, %+v. Exiting...\n", err)
-		return nil
+		return []string{}
 	}
 
 	fmt.Println("Working on groups ", getGroupNames(groups))
-
-	canonicalVersion, err := semver.Make(p.canonical)
-	if err != nil {
-		fmt.Errorf("Failed to parse canonical version, %+v\n", err)
-		return nil
-	}
 
 	for _, g := range groups {
 		targets, err := g.GetTargetInstances(canonicalVersion, p.minimumInstanceCount)

--- a/terminator_test.go
+++ b/terminator_test.go
@@ -155,7 +155,7 @@ func TestSuite(t *testing.T) {
 		expectedTerminations []string
 	}{
 		{
-			name:           "Delete all instances in auto scaling group where all instances are healthy fully, because min instance count is zero.",
+			name:           "Given a minimum instance count of 0, remove all unmatching instances from a healthy auto scaling group.",
 			customVersions: map[string]string{},
 			p: parameters{
 				region:               "europa-westmoreland-1",
@@ -164,6 +164,8 @@ func TestSuite(t *testing.T) {
 				isDryRun:             false,
 				canonical:            "5.0.0",
 			},
+			// Group1 has an unhealthy instance, therefore group is considered unhealthy as a whole, and ignored.
+			// All instances in Group2 don't match the canonical version of 5.0.0 and are therefore terminated.
 			expectedTerminations: []string{"D", "E", "F", "G"},
 		},
 		{
@@ -174,9 +176,10 @@ func TestSuite(t *testing.T) {
 				minimumInstanceCount: 0,
 				versionURL:           "",
 				isDryRun:             false,
-				autoScalingGroups:    []string{"Group2"}, // Filter to Group1 and Group2
+				autoScalingGroups:    []string{"Group2"}, // Filter to Group2
 				canonical:            "1.0.0",
 			},
+			// Group1 is ignored, due to the filter.
 			expectedTerminations: []string{"D", "E", "F", "G"},
 		},
 		{
@@ -255,7 +258,8 @@ func TestSuite(t *testing.T) {
 				isDryRun:             false,
 				canonical:            "0.9.9",
 			},
-			// C isn't terminated because it's OutOfService.
+			// Group1 is ignored because C is OutOfService.
+			// G remains inservice, as it matches the canonical version.
 			expectedTerminations: []string{"D", "E", "F"},
 		},
 		{

--- a/terminator_test.go
+++ b/terminator_test.go
@@ -155,7 +155,7 @@ func TestSuite(t *testing.T) {
 		expectedTerminations []string
 	}{
 		{
-			name:           "Delete fully, regardless of health because min instance count is zero.",
+			name:           "Delete all instances in auto scaling group where all instances are healthy fully, because min instance count is zero.",
 			customVersions: map[string]string{},
 			p: parameters{
 				region:               "europa-westmoreland-1",
@@ -164,7 +164,7 @@ func TestSuite(t *testing.T) {
 				isDryRun:             false,
 				canonical:            "5.0.0",
 			},
-			expectedTerminations: []string{"A", "B", "C", "D", "E", "F", "G"},
+			expectedTerminations: []string{"D", "E", "F", "G"},
 		},
 		{
 			name:           "Only delete items in Group2, because of the filter.",
@@ -192,7 +192,7 @@ func TestSuite(t *testing.T) {
 			expectedTerminations: []string{},
 		},
 		{
-			name:           "Only delete unhealthy instances if all versions match",
+			name:           "Don't do anything to the group if all instances match the canonical version",
 			customVersions: map[string]string{},
 			p: parameters{
 				region:               "europa-westmoreland-1",
@@ -201,7 +201,7 @@ func TestSuite(t *testing.T) {
 				isDryRun:             false,
 				canonical:            "0.0.0",
 			},
-			expectedTerminations: []string{"C"},
+			expectedTerminations: []string{},
 		},
 		{
 			name:           "Don't do anything to the group if you would leave the cluster unhealthy.",
@@ -218,7 +218,7 @@ func TestSuite(t *testing.T) {
 			expectedTerminations: []string{"D", "E"},
 		},
 		{
-			name: "Delete the old versions ",
+			name: "Delete the old versions",
 			customVersions: map[string]string{
 				"A": "1.0.0",
 				"B": "1.0.0",
@@ -238,7 +238,7 @@ func TestSuite(t *testing.T) {
 			expectedTerminations: []string{"D"},
 		},
 		{
-			name: "Delete the new versions! (Canonical is set to older version)",
+			name: "Delete the new versions (Canonical is set to older version). Ignore any unhealthy groups.",
 			customVersions: map[string]string{
 				"A": "0.9.9",
 				"B": "1.0.0",
@@ -256,7 +256,7 @@ func TestSuite(t *testing.T) {
 				canonical:            "0.9.9",
 			},
 			// C isn't terminated because it's OutOfService.
-			expectedTerminations: []string{"B", "C", "D", "E", "F"},
+			expectedTerminations: []string{"D", "E", "F"},
 		},
 		{
 			name: "Don't delete too many old versions and potentially take the service down!",


### PR DESCRIPTION
…p if it includes any unhealthy instances, and only perform a check for mismatching versions when it has successfully retrieved the versions for all instances in a group.